### PR TITLE
Add mast.hpc.social

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ If you are in academia and do not know where to register your account in the fed
 - [Fediphilosophy](https://fediphilosophy.org/) (Mastodon instance for academic philosophers; [server guide & rules](https://github.com/xiyudu/fediphilosophy))
 - [Fediscience](https://fediscience.org) (General science)
 - [glammr.us](https://glammr.us/about) (galleries, libraries, archives, museums, and special collections, records, memory work)
+- [High Performance Computing](https://mast.hpc.social)
 - [Human Computer Interaction](https://hci.social)
 - [Humanities Commons](https://hcommons.social)
 - [Julia Language](https://julialang.social/)
@@ -144,8 +145,6 @@ If you are in academia and do not know where to register your account in the fed
 - [Visualisation](https://vis.social) (SciArt, SciComm, data visualization, creative coding)
 - [Zirkus](https://zirk.us) (literature, philosophy, film, music, culture, politics, history, architecture)
 - [ecoevo.social](https://ecoevo.social) (biological ecology and evolution) 
-
-> If you are working in or with HPC and would like to join a dedicated Mastodon server, [Dr. Alan Sill (Texas Tech University)](https://github.com/alansill) is currently running a survey to estimate interest. You can find the survey at [survey.hpc.social](https://survey.hpc.social).
 
 > You can find [a comprehensive list of these and many more academic Mastodon servers on fediscience.org](https://fediscience.org/server-list.html). Visit [fedi.tips](https://fedi.tips) for a general beginners guide to Mastodon. [hcommons.org has created a quick start guide specifically for researchers in the humanities](https://hcommons.org/docs/mastodon-quick-start-guide-for-humanities-scholars/) that also includes a short list of instances that are tailored to humanities specifically.
 


### PR DESCRIPTION
Mastodon instance for the hpc.social domain is now up.