### PR TITLE
Addition of Social Work as a discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following are curated lists of academic accounts on Mastodon by discipline. 
 - [Religion](https://docs.google.com/spreadsheets/d/1uBwBthFWMCTKxMEn6liNosDX8bOEmoNnFZnWD_xu_7E/) (Google Spreadsheet;[Form to add yourself](https://docs.google.com/forms/d/e/1FAIpQLSePifeeWOinGtsLc9FyRBT-W6nkzJ84f9f_eQWioNaTY2OgfQ/viewform))
 - [Science and Technology Studies (STS)](https://jwyg.github.io/mastodon-sts/)
 - [Semantic Web+](https://semantisch.github.io/SemanticWeb/) ([Form to add yourself](https://forms.gle/pjNmNG6xwzU28Y3o6))
+- [Social Workers on Mastodon](https://docs.google.com/spreadsheets/d/e/2PACX-1vQ1JfdvsTY1HZWEAIvk5kIE_ueXjvnZSdMpytah9jNEzlJj0eEHsOdiP2DIpL_L58rKLYILWTCce3Pz/pubhtml?gid=1241234414&single=true) (a Google Sheet, with a [Form to Add Your Username](https://forms.gle/jK1JswjiYyJAfwnQ6))
 - [Sociology](https://trutzig89182.github.io/Mastodon-Sociologists/)
 - [Technology Law & Policy](https://liveuclac-my.sharepoint.com/:x:/g/personal/ucqnmve_ucl_ac_uk/ES11jfqXsNVNpd1roXFokNkBzRux6n2xThtV4CsgqpSj8g?e=rKrajY) (Spreadsheet)
 - [Theologidons](https://docs.google.com/spreadsheets/d/1Es07iNFBy2fRpOPd7ZHw-MMqHG5Vi4wHvvO1xE3Co_k/) (Google Spreadsheet; [Form to add yourself](https://docs.google.com/forms/d/1hyWwyXQpg5xqclT5d630QMfbunzaf14owBX5fQWNmFw/viewform))
@@ -114,6 +115,7 @@ There are also groups over on Mastodon that you can use to connect to fellow aca
 - [@rstats@a.gup.pe](https://a.gup.pe/u/rstats) (The R language for statistical computing)
 - [@seresearchers@a.gup.pe](https://a.gup.pe/u/seresearchers) (Software Engineering)
 - [@semanticweb@a.gup.pe](https://a.gup.pe/u/semanticweb) (Semantic Web)
+- [@socialwork@a.gup.pe](https://a.gup.pe/u/socialwork)
 - [@sociology@a.gup.pe](https://a.gup.pe/u/sociology)
 - [@WebScience@a.gup.pe](https://a.gup.pe/u/webscience) (Web Science)
 


### PR DESCRIPTION
Adds a Google Sheet for social workers to add themselves to a list and a link to the @SocialWork group on Guppe.