### PR TITLE
Add mastodon.energy to server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If you are in academia and do not know where to register your account in the fed
 - [Law Professors](https://mastodon.lawprofs.org/)
 - [Legal General Interest](https://esq.social)
 - [Mastodon.Art](https://mastodon.art/explore) (Creative Arts)
+- [Mastodon.energy](https://mastodon.energy/explore) (Energy & climate professionals)
 - [Mathstodon](https://mathstodon.xyz)
 - [Mapstodon](https://mapstodon.space/) (GIS, mapping, geospatial and cartography professionals and enthusiasts)
 - [Med-Mammoth](https://med-mammoth.com/)


### PR DESCRIPTION
Thanks for collecting those links. I've added the server mastodon.energy as it is heavily used for communicating topics from the energy science domain.